### PR TITLE
Add playnext command to bot.py

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1302,6 +1302,22 @@ class MusicBot(discord.Client):
             )
         return True
 
+    async def cmd_playnext(self, message, player, channel, author, permissions, leftover_args, song_url):
+        """
+        Usage:
+            {command_prefix}playnext song_link
+            {command_prefix}playnext text to search for
+            {command_prefix}playnext spotify_uri
+
+        Adds the song to the beginning of the playlist.  If a link is not provided, the first
+        result from a youtube search is added to the front of the queue.
+
+        If enabled in the config, the bot will also support Spotify URIs, however
+        it will use the metadata (e.g song name and artist) to find a YouTube
+        equivalent of the song. Streaming from Spotify is not possible.
+        """
+        return await self._cmd_play(message, player, channel, author, permissions, leftover_args, song_url, True)
+
     async def cmd_play(self, message, player, channel, author, permissions, leftover_args, song_url):
         """
         Usage:
@@ -1309,12 +1325,22 @@ class MusicBot(discord.Client):
             {command_prefix}play text to search for
             {command_prefix}play spotify_uri
 
-        Adds the song to the playlist.  If a link is not provided, the first
-        result from a youtube search is added to the queue.
+        Adds the song to the end of the playlist. If a link is not provided, the first
+        result from a youtube search is added to the end of the queue.
 
         If enabled in the config, the bot will also support Spotify URIs, however
         it will use the metadata (e.g song name and artist) to find a YouTube
         equivalent of the song. Streaming from Spotify is not possible.
+        """
+        return await self._cmd_play(message, player, channel, author, permissions, leftover_args, song_url, False)
+        
+
+    async def _cmd_play(self, message, player, channel, author, permissions, leftover_args, song_url, head=False):
+        """
+        Adds the song to the playlist according to the "head" flag. If head is True,
+        the song is added to the beginning of the queue, otherwise it is added to the 
+        end of the queue. If a link is not provided, the first result from a youtube
+        search is added to the queue.
         """
 
         song_url = song_url.strip('<>')
@@ -1535,7 +1561,7 @@ class MusicBot(discord.Client):
                     )
 
                 try:
-                    entry, position = await player.playlist.add_entry(song_url, channel=channel, author=author)
+                    entry, position = await player.playlist.add_entry(song_url, head, channel=channel, author=author)
 
                 except exceptions.WrongEntryTypeError as e:
                     if e.use_url == song_url:

--- a/musicbot/playlist.py
+++ b/musicbot/playlist.py
@@ -55,7 +55,7 @@ class Playlist(EventEmitter, Serializable):
         return entry
 
 
-    async def add_entry(self, song_url, **meta):
+    async def add_entry(self, song_url, head=False, **meta):
         """
             Validates and adds a song_url to be played. This does not start the download of the song.
 
@@ -112,7 +112,7 @@ class Playlist(EventEmitter, Serializable):
             self.downloader.ytdl.prepare_filename(info),
             **meta
         )
-        self._add_entry(entry)
+        self._add_entry(entry, head=head)
         return entry, len(self.entries)
 
     async def add_stream_entry(self, song_url, info=None, **meta):


### PR DESCRIPTION
cmd_play is now _cmd_play and takes an additional flag. The flag is used
by the new cmd_play and cmd_playnext to determine which side of the
playlist songs get added to. Songs get added to the front of the queue
if the flag, "head", is true, otherwise they get added to the back of
the queue.

After creating your pull request, tick these boxes if they are applicable to you.

- [ ] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [ ] I have tested my changes on Python 3.5/3.6

----

### Description



### Related issues (if applicable)

